### PR TITLE
Add zip command to facilitate uploading Lambda functions with the AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:12
 
+RUN apt-get update && apt-get install -y zip && rm -rf /var/lib/apt/lists/*
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip
 RUN ./aws/install && aws --version
 


### PR DESCRIPTION
Some AWS commands, such as those that update the code in Lambda functions, require that the resources be put in a zip file before being passed to the AWS CLI.  It would be nice to have the zip command available in the image.